### PR TITLE
Implement get_link_targets

### DIFF
--- a/pattern_matcher/couch_mongo_db_test.py
+++ b/pattern_matcher/couch_mongo_db_test.py
@@ -50,6 +50,14 @@ def test_node_exists(cm_db: CouchMongoDB):
     ), "concept:ent (all lower case) shouldn't exist"
 
 
+def test_link_exists(cm_db: CouchMongoDB):
+    assert cm_db.link_exists(
+        "Inheritance",
+        ["83638a4598185ca13b43140029b494f7", "4581aeda36530cca36f83d53d6fff0c3"],
+    )
+    assert not cm_db.link_exists("Similarity", ["0123456789abcdef", "fedcba9876543210"])
+
+
 def test_get_node_handle(cm_db: CouchMongoDB):
     assert cm_db.get_node_handle("Concept", "ent") == "13ba6904f6987307e3bce206c350fdf1"
 
@@ -95,3 +103,39 @@ def test_get_matched_links(cm_db: CouchMongoDB):
     assert all(
         isinstance(h, str) for h in res
     ), "get_matched_links should return a list of strings"
+
+
+def test_get_link_handle_should_be_equal_to_generate_link_handle(cm_db: CouchMongoDB):
+    link_handle = cm_db.get_link_handle(
+        "Similarity",
+        ["83638a4598185ca13b43140029b494f7", "c8ec81db392b765d010fa1eaf052b51e"],
+    )
+    generated_link_handle = cm_db._generate_link_handle(
+        "df5aa67f61bf6485dc74cd319e5681a0",
+        ["83638a4598185ca13b43140029b494f7", "c8ec81db392b765d010fa1eaf052b51e"],
+    )
+    assert (
+        link_handle == generated_link_handle
+    ), "link_handle and generated_link_handle should be equal"
+
+
+def test_generate_link_handle(cm_db: CouchMongoDB):
+    handle = cm_db._generate_link_handle(
+        "8c9f9d98fbfd0563ce23bf8ed77a7ee8",
+        ["83638a4598185ca13b43140029b494f7", "4581aeda36530cca36f83d53d6fff0c3"],
+    )
+    assert handle == "bd49fe6a8f57c7e6ec77d7b8898372d6", "handle should be equal to 'bd49fe6a8f57c7e6ec77d7b8898372d6'"
+
+
+def test_get_doc(cm_db: CouchMongoDB):
+    doc = cm_db._get_doc("bd49fe6a8f57c7e6ec77d7b8898372d6")
+    assert isinstance(doc, dict), "get_doc should return a dict"
+    assert "_id" in doc, "get_doc should return a dict with an _id"
+
+    doc = cm_db._get_doc("bd49fe6a8f57c7e6ec77d7b8898372d6", cm_db.COLL_LINKS_3)
+    assert isinstance(doc, dict), "get_doc should return a dict"
+    assert "_id" in doc, "get_doc should return a dict with an _id"
+
+    assert cm_db._get_doc("inexistent key", cm_db.COLL_LINKS) is None, "get_doc should return None for inexistent key"
+
+    assert cm_db._get_doc("bd49fe6a8f57c7e6ec77d7b8898372d6", cm_db.COLL_LINKS) is None, "get_doc should return None if the doc doesn't exist"

--- a/scripts/hashing.py
+++ b/scripts/hashing.py
@@ -18,8 +18,9 @@ class Hasher:
     set_from = expression.SET_FROM - 1
     expression[set_from:] = sorted(expression[set_from:], key=lambda e: e._id)
 
-  def apply_alg(self, value: str) -> str:
-    return self.algorithm(value.encode("utf-8")).digest().hex()
+  @classmethod
+  def apply_alg(cls, value: str) -> str:
+    return cls.algorithm(value.encode("utf-8")).digest().hex()
 
   def search_by_name(self, name: str) -> AtomType:
     return self.atom_type_dict.get(name, None)


### PR DESCRIPTION
This PR:
- Implements `get_link_targets`
- Adds tests
- Adds `_get_doc` to make easier the doc retrieving from `mongodb`.
- Fixes related helper functions (`_generate_link_handle`, `_get_link_type_handle`)