### PR TITLE
Implements Mongo get_node_name & tests

### DIFF
--- a/das/pattern_matcher/db_mongo.py
+++ b/das/pattern_matcher/db_mongo.py
@@ -213,3 +213,9 @@ class DASMongoDB(DBInterface):
 
     def get_matched_type_template(self, template: List[Any]) -> List[str]:
         return list(self._retrieve_mongo_documents_by_type_match(template))
+
+    def get_node_name(self, node_handle: str) -> str:
+        document = self.node_documents.get(node_handle, None)
+        if not document:
+            raise ValueError(f'Invalid node handle: {node_handle}')
+        return document[MongoFieldNames.NODE_NAME]

--- a/das/pattern_matcher/db_mongo_test.py
+++ b/das/pattern_matcher/db_mongo_test.py
@@ -90,3 +90,14 @@ def test_get_matched_links(das_db: DASMongoDB):
     assert all(
         isinstance(h, str) for h in res
     ), "get_matched_links should return a list of strings"
+
+
+def test_get_node_name(das_db: DASMongoDB):
+    assert (
+        das_db.get_node_name("13ba6904f6987307e3bce206c350fdf1")
+        == "\"Concept:ent\""
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        das_db.get_node_name("invalid_handle")
+    assert "Invalid node handle: invalid_handle" == str(excinfo.value)


### PR DESCRIPTION
This PR adds `get_node_name` to only mongo backed implementation of `DBInterface`, and test for it as well. 