### PR TITLE
Use same environment file for both DAS and service README.md

### DIFF
--- a/das/README.md
+++ b/das/README.md
@@ -8,15 +8,8 @@ These scripts run actions related to DAS context (Eg. conversion, loading).
 Assuming there is a running console where the current directory is the root of this project:
 
 ```sh
-# MongoDB variables
-export DAS_MONGODB_HOSTNAME=mongo
-export DAS_MONGODB_PORT=27017
-# Couchbase variables (Using 8Gb of RAM)
-export DAS_COUCHBASE_HOSTNAME=couchbase
-export DAS_COUCHBASE_BUCKET_RAMSIZE=$((8*1024))
-# Change the following values when running on a public instance (used by MongoDB and Couchbase)
-export DAS_DATABASE_USERNAME=dbadmin
-export DAS_DATABASE_PASSWORD=dassecret
+# Export necessary environment
+source environment
 
 # Build and run containers
 docker-compose up -d

--- a/environment
+++ b/environment
@@ -1,0 +1,9 @@
+# MongoDB variables
+export DAS_MONGODB_HOSTNAME=mongo
+export DAS_MONGODB_PORT=27017
+# Couchbase variables (Using 8Gb of RAM)
+export DAS_COUCHBASE_HOSTNAME=couchbase
+export DAS_COUCHBASE_BUCKET_RAMSIZE=$((8*1024))
+# Change the following values when running on a public instance (used by MongoDB and Couchbase)
+export DAS_DATABASE_USERNAME=dbadmin
+export DAS_DATABASE_PASSWORD=dassecret

--- a/service/README.md
+++ b/service/README.md
@@ -415,6 +415,11 @@ das_service   latest    fb5f0224202f   2 minutes ago   1.95GB
 
 ## Step 3 - build extra docker images and start the service
 
+Prepare environment, by exporting all necessary variables:
+```
+$ source environment
+```
+
 There are two other Docker images to build but this can be done while we put the service container up. Just call the following:
 
 ```


### PR DESCRIPTION
Move all environment setup into `environment` file. Add `source environment` into README.md to setup environment.