### PR TITLE
Faster MeTTa parser for "well formed" files

### DIFF
--- a/das/canonical_parser.py
+++ b/das/canonical_parser.py
@@ -1,6 +1,11 @@
+from enum import Enum, auto
+import datetime
 from das.logger import logger
 from das.expression_hasher import ExpressionHasher
-from enum import Enum, auto
+from das.database.couchbase_schema import CollectionNames as CouchbaseCollections
+from das.database.mongo_schema import CollectionNames as MongoCollections
+from das.key_value_file import write_key_value, key_value_generator, key_value_targets_generator, sort_file
+from das.database.db_interface import WILDCARD
 
 class State(str, Enum):
     READING_TYPES = auto()
@@ -9,16 +14,277 @@ class State(str, Enum):
 
 class CanonicalParser:
 
-    def __init__(self):
+    def __init__(self, db, allow_duplicates):
         self.current_line_count = 1
-        self.bulk_typedef_insertion = []
-        self.bulk_terminal_insertion = []
+        self.mongo_typedef = []
+        self.mongo_terminal = []
+        self.mongo_expression = []
+        self.typedef_mark_hash = ExpressionHasher.named_type_hash(":")
+        self.base_type_hash = ExpressionHasher.named_type_hash("Type")
+        self.db = db
+        self.allow_duplicates = allow_duplicates
+        self.temporary_file_name = {
+            s.value: f"/tmp/parser_{s.value}.txt" for s in CouchbaseCollections
+        }
+        self.pattern_black_list = None
+
 
     def _add_typedef(self, name, stype):
-        print(f"typedef {name} {stype}")
+        stype_hash = ExpressionHasher.named_type_hash(stype)
+        name_hash = ExpressionHasher.named_type_hash(name)
+        composite_type = [self.typedef_mark_hash, stype_hash, self.base_type_hash]
+        composite_type_hash = ExpressionHasher.composite_hash(composite_type)
+        id_hash = ExpressionHasher.expression_hash(self.typedef_mark_hash, [name_hash, stype_hash])
+        self.mongo_typedef.append({
+            "_id": id_hash,
+            "composite_type_hash": composite_type_hash,
+            "named_type": name,
+            "named_type_hash": name_hash,
+        })
             
     def _add_terminal(self, name, stype):
-        print(f"terminal <{name}> {stype}")
+        stype_hash = ExpressionHasher.named_type_hash(stype)
+        name_hash = ExpressionHasher.named_type_hash(name)
+        id_hash = ExpressionHasher.terminal_hash(stype, name)
+        self.mongo_terminal.append({
+            "_id": id_hash,
+            "composite_type_hash": stype_hash,
+            "name": name,
+            "named_type": stype,
+        })
+
+    def _add_expression(self, expression, composite_type, toplevel, named_type, composite_type_hash):
+        named_type_hash = ExpressionHasher.named_type_hash(named_type)
+        id_hash = ExpressionHasher.expression_hash(named_type_hash, expression[1:])
+        document = {
+            "_id": id_hash,
+            "composite_type_hash": composite_type_hash,
+            "is_toplevel": toplevel,
+            "composite_type": composite_type,
+            "named_type": named_type,
+            "named_type_hash": named_type_hash,
+        }
+        for i in range(1, len(expression)):
+            document[f"key_{i - 1}"] = expression[i]
+        self.mongo_expression.append(document)
+
+    def _mongo_insert_many(self, collection, bulk_insertion):
+        try:
+            collection.insert_many(bulk_insertion, ordered=False)
+        except Exception as e:
+            if not self.allow_duplicates:
+                logger().error(str(e))
+
+    def _flush_terminals(self):
+        logger().info(f"Flushing terminals")
+        if self.mongo_typedef:
+            mongo_collection = self.db.mongo_db[MongoCollections.ATOM_TYPES]
+            self._mongo_insert_many(mongo_collection, self.mongo_typedef)
+        if self.mongo_terminal:
+            mongo_collection = self.db.mongo_db[MongoCollections.NODES]
+            self._mongo_insert_many(mongo_collection, self.mongo_terminal)
+        with open(self.temporary_file_name[CouchbaseCollections.NAMED_ENTITIES], "w") as named_entities:
+            for document in self.mongo_terminal:
+                write_key_value(named_entities, document["_id"], document["name"])
+        self.mongo_typedef = None
+        self.mongo_terminal = None
+        logger().info(f"Terminals flushed")
+
+    def _sort_files(self):
+        sort_file(self.temporary_file_name[CouchbaseCollections.OUTGOING_SET])
+        sort_file(self.temporary_file_name[CouchbaseCollections.INCOMING_SET])
+        sort_file(self.temporary_file_name[CouchbaseCollections.PATTERNS])
+        sort_file(self.temporary_file_name[CouchbaseCollections.TEMPLATES])
+
+    def _build_key_value_files(self):
+        outgoing = open(self.temporary_file_name[CouchbaseCollections.OUTGOING_SET], "w")
+        incoming = open(self.temporary_file_name[CouchbaseCollections.INCOMING_SET], "w")
+        patterns = open(self.temporary_file_name[CouchbaseCollections.PATTERNS], "w")
+        template = open(self.temporary_file_name[CouchbaseCollections.TEMPLATES], "w")
+        for expression in self.mongo_expression:
+            elements = [expression[k] for k in expression.keys() if k.startswith("key")]
+            for target in elements:
+                write_key_value(outgoing, expression["_id"], target)
+                write_key_value(incoming, target, expression["_id"])
+            if expression["named_type"] not in self.pattern_black_list:
+                arity = len(elements)
+                type_hash = expression["named_type_hash"]
+                keys = []
+                keys.append([WILDCARD, *elements])
+                if arity == 1:
+                    keys.append([type_hash, WILDCARD])
+                    keys.append([WILDCARD, elements[0]])
+                    keys.append([WILDCARD, WILDCARD])
+                elif arity == 2:
+                    keys.append([type_hash, elements[0], WILDCARD])
+                    keys.append([type_hash, WILDCARD, elements[1]])
+                    keys.append([type_hash, WILDCARD, WILDCARD])
+                    keys.append([WILDCARD, elements[0], elements[1]])
+                    keys.append([WILDCARD, elements[0], WILDCARD])
+                    keys.append([WILDCARD, WILDCARD, elements[1]])
+                    keys.append([WILDCARD, WILDCARD, WILDCARD])
+                elif arity == 3:
+                    keys.append([type_hash, elements[0], elements[1], WILDCARD])
+                    keys.append([type_hash, elements[0], WILDCARD, elements[2]])
+                    keys.append([type_hash, WILDCARD, elements[1], elements[2]])
+                    keys.append([type_hash, elements[0], WILDCARD, WILDCARD])
+                    keys.append([type_hash, WILDCARD, elements[1], WILDCARD])
+                    keys.append([type_hash, WILDCARD, WILDCARD, elements[2]])
+                    keys.append([type_hash, WILDCARD, WILDCARD, WILDCARD])
+                    keys.append([WILDCARD, elements[0], elements[1], elements[2]])
+                    keys.append([WILDCARD, elements[0], elements[1], WILDCARD])
+                    keys.append([WILDCARD, elements[0], WILDCARD, elements[2]])
+                    keys.append([WILDCARD, WILDCARD, elements[1], elements[2]])
+                    keys.append([WILDCARD, elements[0], WILDCARD, WILDCARD])
+                    keys.append([WILDCARD, WILDCARD, elements[1], WILDCARD])
+                    keys.append([WILDCARD, WILDCARD, WILDCARD, elements[2]])
+                    keys.append([WILDCARD, WILDCARD, WILDCARD, WILDCARD])
+            for key in keys:
+                write_key_value(patterns, key, [expression["_id"], *elements])
+            write_key_value(template, expression["composite_type_hash"], [expression["_id"], *elements])
+            write_key_value(template, expression["named_type_hash"], [expression["_id"], *elements])
+        for file in [outgoing, incoming, patterns, template]:
+            file.close()
+        self._sort_files()
+
+    def _populate_mongo_links(self):
+        bulk_insertion_1 = []
+        bulk_insertion_2 = []
+        bulk_insertion_N = []
+        for expression in self.mongo_expression:
+            elements = [expression[k] for k in expression.keys() if k.startswith("key")]
+            arity = len(elements)
+            if arity == 1:
+                bulk_insertion_1.append(expression)
+            elif arity == 2:
+                bulk_insertion_2.append(expression)
+            else:
+                bulk_insertion_N.append(expression)
+        if bulk_insertion_1:
+            mongo_collection = self.db.mongo_db[MongoCollections.LINKS_ARITY_1]
+            self._mongo_insert_many(mongo_collection, bulk_insertion_1)
+        if bulk_insertion_2:
+            mongo_collection = self.db.mongo_db[MongoCollections.LINKS_ARITY_2]
+            self._mongo_insert_many(mongo_collection, bulk_insertion_2)
+        if bulk_insertion_N:
+            mongo_collection = self.db.mongo_db[MongoCollections.LINKS_ARITY_N]
+            self._mongo_insert_many(mongo_collection, bulk_insertion_N)
+
+    def _populate_couchbase_table(self, collection_name, use_targets, merge_rest, update):
+        file_name = self.temporary_file_name[collection_name]
+        couchbase_collection = self.db.couch_db.collection(collection_name)
+        generator = key_value_targets_generator if use_targets else key_value_generator
+        for key, value, block_count in generator(file_name, merge_rest=merge_rest):
+            assert not (block_count > 0 and update)
+            if block_count == 0:
+                if update:
+                    outdated = None
+                    try:
+                        outdated = couchbase_collection.get(key)
+                    except Exception:
+                        pass
+                    if outdated is None:
+                        couchbase_collection.upsert(key, list(set(value)), timeout=datetime.timedelta(seconds=100))
+                    else:
+                        converted_outdated = []
+                        for entry in outdated.content:
+                            if isinstance(entry, str):
+                                converted_outdated.append(entry)
+                            else:
+                                handle = entry[0]
+                                targets = entry[1]
+                                converted_outdated.append(tuple([handle, tuple(targets)]))
+                        couchbase_collection.upsert(key, list(set([*converted_outdated, *value])), timeout=datetime.timedelta(seconds=100))
+                else:
+                    couchbase_collection.upsert(key, value, timeout=datetime.timedelta(seconds=100))
+            else:
+                if block_count == 1:
+                    first_block = couchbase_collection.get(key)
+                    couchbase_collection.upsert(f"{key}_0", first_block.content, timeout=datetime.timedelta(seconds=100))
+                couchbase_collection.upsert(key, block_count + 1)
+                couchbase_collection.upsert(f"{key}_{block_count}", value, timeout=datetime.timedelta(seconds=100))
+
+    def _populate_couchbase(self):
+        self._populate_couchbase_table(CouchbaseCollections.OUTGOING_SET, False, False, False),
+        self._populate_couchbase_table(CouchbaseCollections.INCOMING_SET, False, False, False),
+        self._populate_couchbase_table(CouchbaseCollections.PATTERNS, True, False, False),
+        self._populate_couchbase_table(CouchbaseCollections.TEMPLATES, True, False, False),
+        self._populate_couchbase_table(CouchbaseCollections.NAMED_ENTITIES, False, True, False)
+
+    def _flush_expressions(self):
+        logger().info(f"Flushing expressions")
+        logger().info(f"Building key-value files")
+        self._build_key_value_files()
+        logger().info(f"Populating MongoDB link tables")
+        self._populate_mongo_links()
+        logger().info(f"Populating Couchbase")
+        self._populate_couchbase()
+        logger().info(f"Expressions flushed")
+
+    def _parse_expression(self, expression):
+        slist = []
+        stack = []
+        composite_type_stack = []
+        composite_type_hash_stack = []
+        named_type_stack = []
+        state = 0
+        for c in expression:
+            if state == 0:
+                if c == '(':
+                   stack.append("(")
+                elif c == ' ':
+                    if slist:
+                        s = "".join(slist)
+                        stack.append(s)
+                        named_type_stack.append(s)
+                        named_type_hash = ExpressionHasher.named_type_hash(s)
+                        composite_type_stack.append(named_type_hash)
+                        composite_type_hash_stack.append(named_type_hash)
+                        slist = []
+                elif c == ')':
+                    expression = []
+                    composite_type = []
+                    term = stack.pop(-1)
+                    hash_list = []
+                    while term != "(":
+                        expression.append(term)
+                        composite_type.append(composite_type_stack.pop())
+                        hash_list.append(composite_type_hash_stack.pop())
+                        named_type = named_type_stack.pop()
+                        term = stack.pop(-1)
+                    expression.reverse()
+                    composite_type.reverse()
+                    hash_list.reverse()
+                    composite_type_hash = ExpressionHasher.composite_hash(hash_list)
+                    if stack:
+                        self._add_expression(expression, composite_type, False, named_type, composite_type_hash)
+                        id_hash = ExpressionHasher.expression_hash(ExpressionHasher.named_type_hash(named_type), expression[1:])
+                        stack.append(id_hash)
+                        named_type_stack.append(":")
+                        composite_type_stack.append(composite_type)
+                        composite_type_hash_stack.append(composite_type_hash)
+                    else:
+                        self._add_expression(expression, composite_type, True, named_type, composite_type_hash)
+                elif c == '"':
+                    state = 1
+                else:
+                    slist.append(c)
+            elif state == 1:
+                if c == '"' and previous != '\\':
+                    s = "".join(slist).split()
+                    stype = s[0]
+                    name = " ".join(s[1:])
+                    stack.append(ExpressionHasher.terminal_hash(stype, name))
+                    named_type_stack.append(stype)
+                    named_type_hash = ExpressionHasher.named_type_hash(stype)
+                    composite_type_stack.append(named_type_hash)
+                    composite_type_hash_stack.append(named_type_hash)
+                    slist = []
+                    state = 0
+                else:
+                    slist.append(c)
+            previous = c
+        self._check(len(stack) == 0)
             
     def _check(self, flag):
         if not flag:
@@ -26,6 +292,7 @@ class CanonicalParser:
             assert False
         
     def parse(self, path):
+        logger().info(f"Parsing {path}")
         self.current_state = State.READING_TYPES
         with open(path, "r") as file:
             for line in file:
@@ -48,5 +315,10 @@ class CanonicalParser:
                         self._add_terminal(terminal_name, stype)
                     else:
                         self.current_state = State.READING_EXPRESSIONS
+                        self._flush_terminals()
                 if self.current_state == State.READING_EXPRESSIONS:
                     self._check(expression[0] != "(:")
+                    self._check(self.current_line.startswith("("))
+                    self._check(self.current_line.endswith(")"))
+                    self._parse_expression(self.current_line)
+        self._flush_expressions()

--- a/das/canonical_parser.py
+++ b/das/canonical_parser.py
@@ -1,0 +1,53 @@
+from das.logger import logger
+from das.expression_hasher import ExpressionHasher
+from enum import Enum, auto
+
+class State(str, Enum):
+    READING_TYPES = auto()
+    READING_TERMINALS = auto()
+    READING_EXPRESSIONS = auto()
+
+class CanonicalParser:
+
+    def __init__(self):
+        self.current_line_count = 1
+        self.bulk_typedef_insertion = []
+        self.bulk_terminal_insertion = []
+
+    def _add_typedef(self, name, stype):
+        print(f"typedef {name} {stype}")
+            
+    def _add_terminal(self, name, stype):
+        print(f"terminal <{name}> {stype}")
+            
+    def _check(self, flag):
+        if not flag:
+            print(f"Line {self.current_line_count}: {self.current_line}")
+            print(f"Current state: {self.current_state.name}")
+            assert False
+        
+    def parse(self, path):
+        self.current_state = State.READING_TYPES
+        with open(path, "r") as file:
+            for line in file:
+                self.current_line = line.strip()
+                self.current_line_count += 1
+                expression = self.current_line.split()
+                if self.current_state == State.READING_TYPES:
+                    self._check(expression[0] == "(:")
+                    if expression[1].startswith("\""):
+                        self.current_state = State.READING_TERMINALS
+                    else:
+                        self._check(len(expression) == 3)
+                        type_name = expression[1]
+                        stype = expression[-1].rstrip(")")
+                        self._add_typedef(type_name, stype)
+                if self.current_state == State.READING_TERMINALS:
+                    if expression[0] == "(:":
+                        terminal_name = " ".join(expression[1:-1]).strip("\"")
+                        stype = expression[-1].rstrip(")")
+                        self._add_terminal(terminal_name, stype)
+                    else:
+                        self.current_state = State.READING_EXPRESSIONS
+                if self.current_state == State.READING_EXPRESSIONS:
+                    self._check(expression[0] != "(:")

--- a/das/canonical_parser.py
+++ b/das/canonical_parser.py
@@ -22,8 +22,7 @@ class CanonicalParser:
             
     def _check(self, flag):
         if not flag:
-            print(f"Line {self.current_line_count}: {self.current_line}")
-            print(f"Current state: {self.current_state.name}")
+            print(f"({self.current_state.name}) Line #{self.current_line_count}: {self.current_line}")
             assert False
         
     def parse(self, path):

--- a/das/distributed_atom_space.py
+++ b/das/distributed_atom_space.py
@@ -36,6 +36,7 @@ class DistributedAtomSpace:
         self.db = None
         logger().info(f"New Distributed Atom Space. Database name: {self.database_name}")
         self._setup_database()
+        self.pattern_black_list = []
 
     def _setup_database(self):
         hostname = os.environ.get('DAS_MONGODB_HOSTNAME')
@@ -317,6 +318,7 @@ class DistributedAtomSpace:
         for file_name in knowledge_base_file_list:
             logger().info(f"Knowledge base file: {file_name}")
         shared_data = SharedData()
+        shared_data.pattern_black_list = self.pattern_black_list
 
         parser_threads = [
             ParserThread(KnowledgeBaseFile(self.db, file_name, shared_data))
@@ -352,6 +354,7 @@ class DistributedAtomSpace:
             * Among typedefs, any terminal types (e.g. '(: "my_node_name" my_type)') appear
               after all actual type definitions (e.g. '(: Concept Type)')
             * No "(" or ")" in atom names
+            * Flat type hierarchy (i.e. all types inherit from Type)
 
         A typycal canonical file have all type definition expressions, followed by terminal
         type definition followed by the expressions. Something like:
@@ -375,7 +378,8 @@ class DistributedAtomSpace:
         knowledge_base_file_list = self._get_file_list(source)
         for file_name in knowledge_base_file_list:
             logger().info(f"Knowledge base file: {file_name}")
-        canonical_parser = CanonicalParser()
+        canonical_parser = CanonicalParser(self.db, False)
+        canonical_parser.pattern_black_list = self.pattern_black_list
         for file_name in knowledge_base_file_list:
             canonical_parser.parse(file_name)
         #canonical_parser.populate_indexes()

--- a/das/distributed_atom_space.py
+++ b/das/distributed_atom_space.py
@@ -351,6 +351,7 @@ class DistributedAtomSpace:
             * All typedefs appear before any regular expressions
             * Among typedefs, any terminal types (e.g. '(: "my_node_name" my_type)') appear
               after all actual type definitions (e.g. '(: Concept Type)')
+            * No "(" or ")" in atom names
 
         A typycal canonical file have all type definition expressions, followed by terminal
         type definition followed by the expressions. Something like:

--- a/das/key_value_file.py
+++ b/das/key_value_file.py
@@ -1,0 +1,76 @@
+from das.expression_hasher import ExpressionHasher
+import os
+
+# There is a Couchbase limitation for long values (max: 20Mb)
+# So we set the it to ~15Mb, if this max size is reached
+# we create a new key to store the next 15Mb batch and so on.
+# TODO: move this constant to a proper place
+MAX_COUCHBASE_BLOCK_SIZE = 500000
+
+def sort_file(file_name):
+    os.system(f"sort -t , -k 1,1 {file_name} > {file_name}.sorted")
+    os.rename(f"{file_name}.sorted", file_name)
+
+def write_key_value(file, key, value):
+    if isinstance(key, list):
+        key = ExpressionHasher.composite_hash(key)
+    if isinstance(value, list):
+        value = ",".join(value)
+    line = f"{key},{value}"
+    file.write(line)
+    file.write("\n")
+
+def key_value_generator(input_filename, *, block_size=MAX_COUCHBASE_BLOCK_SIZE, merge_rest=False):
+    last_key = ''
+    last_list = []
+    block_count = 0
+    with open(input_filename, 'r') as fh:
+        for line in fh:
+            line = line.strip()
+            if line == '':
+                continue
+            if merge_rest:
+                v = line.split(",")
+                key = v[0]
+                value = ",".join(v[1:])
+            else:
+                key, value = line.split(",")
+            if last_key == key:
+                last_list.append(value)
+                if len(last_list) >= block_size:
+                    yield last_key, last_list, block_count
+                    block_count += 1
+                    last_list = []
+            else:
+                if last_key != '':
+                    yield last_key, last_list, block_count
+                block_count = 0
+                last_key = key
+                last_list = [value]
+    if last_key != '':
+        yield last_key, last_list, block_count
+
+def key_value_targets_generator(input_filename, *, block_size=MAX_COUCHBASE_BLOCK_SIZE/4, merge_rest=False):
+    last_key = ''
+    last_list = []
+    block_count = 0
+    with open(input_filename, 'r') as fh:
+        for line in fh:
+            line = line.strip()
+            if line == '':
+                continue
+            key, value, *targets = line.split(",")
+            if last_key == key:
+                last_list.append(tuple([value, tuple(targets)]))
+                if len(last_list) >= block_size:
+                    yield last_key, last_list, block_count
+                    block_count += 1
+                    last_list = []
+            else:
+                if last_key != '':
+                    yield last_key, last_list, block_count
+                block_count = 0
+                last_key = key
+                last_list = [tuple([value, tuple(targets)])]
+    if last_key != '':
+        yield last_key, last_list, block_count

--- a/flybase2metta/sql_reader.py
+++ b/flybase2metta/sql_reader.py
@@ -180,6 +180,8 @@ class LazyParser():
 
     def _add_node(self, node_type, node_name):
         # metta
+        node_name = node_name.replace("(", "[")
+        node_name = node_name.replace(")", "]")
         if node_type in TYPED_NAME:
             quoted_node_name = f'"{node_type}:{node_name}"'
             quoted_canonical_node_name = f'"{node_type} {node_type}:{node_name}"'

--- a/flybase2metta/sql_reader.py
+++ b/flybase2metta/sql_reader.py
@@ -182,10 +182,12 @@ class LazyParser():
         # metta
         if node_type in TYPED_NAME:
             quoted_node_name = f'"{node_type}:{node_name}"'
+            quoted_canonical_node_name = f'"{node_type} {node_type}:{node_name}"'
         else:
             quoted_node_name = f'"{node_name}"'
+            quoted_canonical_node_name = f'"{node_type} {node_name}"'
         self.current_node_set.add(f"(: {quoted_node_name} {node_type})")
-        return quoted_node_name
+        return quoted_canonical_node_name
 
     def _add_inheritance(self, node1, node2):
         # metta

--- a/flybase2metta/sql_reader.py
+++ b/flybase2metta/sql_reader.py
@@ -111,7 +111,7 @@ class LazyParser():
     def _open_new_output_file(self):
         if self.current_output_file_number > 1:
             self.current_output_file.close()
-        fname = f"{self.target_dir}/file_{self.current_output_file_number}.metta"
+        fname = f"{self.target_dir}/file_{str(self.current_output_file_number).zfill(3)}.metta"
         self.current_output_file_number += 1
         self.current_output_file = open(fname, "w")
         self._emit_file_header()

--- a/load
+++ b/load
@@ -1,0 +1,3 @@
+./empty-docker-up
+docker cp ./scripts/load_das.py `docker ps | grep 'das_app' | cut -d' ' -f1`:/app/scripts
+docker-compose exec app python3 scripts/load_das.py $2 --knowledge-base $1

--- a/mongodump
+++ b/mongodump
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mongoexport --jsonFormat=canonical -d das -c nodes --authenticationDatabase=admin --uri=mongodb://dbadmin:dassecret@localhost:27017/ >> $1.nodes
+sort -o $1.nodes $1.nodes
+mongoexport --jsonFormat=canonical -d das -c links_2 --authenticationDatabase=admin --uri=mongodb://dbadmin:dassecret@localhost:27017/ >> $1.links_2
+sort -o $1.links_2 $1.links_2
+mongoexport --jsonFormat=canonical -d das -c atom_types --authenticationDatabase=admin --uri=mongodb://dbadmin:dassecret@localhost:27017/ > $1.atom_types
+sort -o $1.atom_types $1.atom_types

--- a/scripts/load_das.py
+++ b/scripts/load_das.py
@@ -7,13 +7,17 @@ def run():
     )
 
     parser.add_argument('--knowledge-base', type=str, help='Path to a file or directory with a MeTTA knowledge base')
+    parser.add_argument('--canonical', help='Optimized load for canonical knowledge bases', action='store_true')
 
     args = parser.parse_args()
 
     das = DistributedAtomSpace()
 
     if args.knowledge_base:
-        das.load_knowledge_base(args.knowledge_base)
+        if args.canonical:
+            das.load_canonical_knowledge_base(args.knowledge_base)
+        else:
+            das.load_knowledge_base(args.knowledge_base)
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
            * The DBs are empty.
            * All MeTTa files have exactly one toplevel expression per line.
            * There are no empty lines.
            * Every "named" expressions (e.g. nodes) mentioned in a given
              expression is already mentioned in a typedef (i.e. something
              like '(: "my_node_name" my_type)' previously IN THE SAME FILE).
            * Every type mentioned in a typedef is already defined IN THE SAME FILE.
            * All expressions are normalized (regarding separators, parenthesis etc)
              like '(: "my_node_name" my_type)' or
              '(Evaluation "name" (Evaluation "name" (List "name" "name")))'. No tabs,
              no double spaces, no spaces after '(', etc.
            * All typedefs appear before any regular expressions
            * Among typedefs, any terminal types (e.g. '(: "my_node_name" my_type)') appear
              after all actual type definitions (e.g. '(: Concept Type)')
            * No "(" or ")" in atom names
            * Flat type hierarchy (i.e. all types inherit from Type)
