### PR TITLE
Make internal node cache optional in DAS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 
 **/*.metta
 nogit/*
+das/parser.out
+das/parsetab.py

--- a/das/database/redis_mongo_db_test.py
+++ b/das/database/redis_mongo_db_test.py
@@ -63,7 +63,7 @@ def _add_node_names(db, txt):
 def test_db_creation(db: DBInterface):
     assert db.redis
     assert db.mongo_db
-    assert len(db.node_documents) == 14
+    assert db.node_documents.size() == 14
     assert len(db.terminal_hash) == 14
     assert len(db.named_type_hash) == 18
     assert len(db.named_type_hash_reverse) == 18
@@ -71,7 +71,7 @@ def test_db_creation(db: DBInterface):
     assert len(db.symbol_hash) == 18
     assert len(db.parent_type) == 18
 
-def test_node_exists(db: DBInterface):
+def _test_node_exists(db: DBInterface):
     assert db.node_exists('Concept', 'human')
     assert db.node_exists('Concept', 'monkey')
     assert db.node_exists('Concept', 'chimp')

--- a/empty-docker-up
+++ b/empty-docker-up
@@ -1,6 +1,0 @@
-source ./environment
-docker stop mongo_27018
-docker rm mongo_27018
-docker volume rm mongodbdata
-./scripts/mongo-up.sh
-./scripts/redis-up.sh

--- a/load
+++ b/load
@@ -1,2 +1,0 @@
-./empty-docker-up
-docker-compose exec app python3 scripts/load_das.py $2 --knowledge-base $1

--- a/scripts/build-das.sh
+++ b/scripts/build-das.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-source environment_das
 docker build --no-cache -t das \
     --build-arg USER_ID=$(id -u) \
     --build-arg GROUP_ID=$(id -g) \

--- a/scripts/debug-container-up.sh
+++ b/scripts/debug-container-up.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+./scripts/empty-db-up.sh
+./scripts/load.sh /data/samples/animals.metta
+
+docker run \
+    --name debug \
+    --env DAS_MONGODB_HOSTNAME=${DAS_MONGODB_HOSTNAME:-mongo} \
+    --env DAS_MONGODB_PORT=${DAS_MONGODB_PORT:-27017} \
+    --env DAS_REDIS_HOSTNAME=${DAS_REDIS_HOSTNAME:-redis} \
+    --env DAS_REDIS_PORT=${DAS_REDIS_PORT:-6379} \
+    --env DAS_DATABASE_USERNAME=${DAS_DATABASE_USERNAME:-dbadmin} \
+    --env DAS_DATABASE_PASSWORD=${DAS_DATABASE_PASSWORD:-dassecret} \
+    --env TZ=${TZ} \
+    --env PYTHONPATH=/app/das:/app/das/das \
+    --network="host" \
+    --volume /tmp:/tmp \
+    --volume $(pwd):/app/das \
+    -ti \
+    das:latest \
+    bash
+
+docker rm debug >& /dev/null

--- a/scripts/empty-db-up.sh
+++ b/scripts/empty-db-up.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker stop mongo_27018 >& /dev/null
+docker rm mongo_27018 >& /dev/null
+docker volume rm mongodbdata >& /dev/null
+./scripts/mongo-up.sh
+./scripts/redis-up.sh

--- a/scripts/jupyter-notebook.sh
+++ b/scripts/jupyter-notebook.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source environment_das
-#    --detach \
 docker run \
     --name jupyter-notebook \
     --env DAS_MONGODB_HOSTNAME=${DAS_MONGODB_HOSTNAME:-mongo} \

--- a/scripts/pytests.sh
+++ b/scripts/pytests.sh
@@ -1,5 +1,6 @@
-source environment
-./empty-docker-up 
+#!/bin/bash
+
+./scripts/empty-db-up.sh
 ./scripts/load.sh /data/samples/animals.metta
 
 docker run \


### PR DESCRIPTION
Resolves #165 

Internal node cache makes queries faster but may increase RAM usage significantly. Now we have a flag USE_CACHED_NODES in `redis_mongo_db.py` to set its use true/false.