### PR TITLE
Bug fix - query status return

### DIFF
--- a/das/pattern_matcher/pattern_matcher.py
+++ b/das/pattern_matcher/pattern_matcher.py
@@ -535,7 +535,7 @@ class Link(Atom):
             return bool(answer.assignments)
         else:
             if DEBUG_LINK: print('matched()', f'leaving 2 self = {self}')
-            return db.link_exists(self.atom_type, target_handles)
+            return db.link_exists(self.atom_type, target_handles) or bool(answer.assignments)
 
 class Variable(Atom):
     """


### PR DESCRIPTION
Query status (matched/not matched) was being incorrectly returned when the wildcard was not at the first level of the query tree